### PR TITLE
Allow forwarding to be configurable, retaining openrouter.ai as a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ OPENROUTER_API_KEY=your-api-key npx anthropic-proxy
 
 Environment variables:
 
-- `OPENROUTER_API_KEY`: Your OpenRouter API key
+- `OPENROUTER_API_KEY`: Your OpenRouter API key (required when using OpenRouter)
+- `ANTHROPIC_PROXY_BASE_URL`: Custom base URL for the transformed OpenAI-format message (default: `openrouter.ai`)
 - `PORT`: The port the proxy server should listen on (default: 3000)
 - `REASONING_MODEL`: The reasoning model to use (default: `google/gemini-2.0-pro-exp-02-05:free`)
 - `COMPLETION_MODEL`: The completion model to use (default: `google/gemini-2.0-pro-exp-02-05:free`)
 - `DEBUG`: Set to `1` to enable debug logging
 
+Note: When `ANTHROPIC_PROXY_BASE_URL` is set to a custom URL, the `OPENROUTER_API_KEY` is not required.
 
 ## Claude Code
 


### PR DESCRIPTION
Hi @maxnowack,

Sorry a PR out of the blue. I came across this project when trying to get my Claude Code to speak to Gemini 2.5 on Vertex. I ended up constructing a bit of a Claude Code -> Anthropic Proxy -> LiteLLM -> Vertex frankenstein.

I don't use OpenRouter because my prompts can't touch clouds (apart from Vertex) so along the way I added a configurable forwarding base url to Anthropic Proxy. I'll keep it on my fork if you don't think it aligns with your vision, but if you think it does - here's a PR!

All feedback welcome and I'll try to make changes in a timely manner.